### PR TITLE
Add cobanov/herdr-ntfysh (Connect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Everything below builds on those primitives — running fleets of agents side by
 | Connect | ![Rust](https://img.shields.io/badge/-555555?logo=rust&logoColor=white&style=flat-square) [herdr-simple-mcp](#connect-over-socket--mcp) | Stateless MCP server, 75 tools, role profiles |
 | Connect | ![JavaScript](https://img.shields.io/badge/-555555?logo=javascript&logoColor=white&style=flat-square) [mimo-code-herdr-plugin](#connect-over-socket--mcp) | MiMo Code agent state in the sidebar |
 | Connect | ![JavaScript](https://img.shields.io/badge/-555555?logo=javascript&logoColor=white&style=flat-square) [herdr-ntfy-notify](#connect-over-socket--mcp) | ntfy push alerts with pane location |
+| Connect | ![Go](https://img.shields.io/badge/-555555?logo=go&logoColor=white&style=flat-square) [herdr-ntfysh](#connect-over-socket--mcp) | ntfy push on done or blocked, zero deps |
 | Connect | ![JavaScript](https://img.shields.io/badge/-555555?logo=javascript&logoColor=white&style=flat-square) [tinysend-herdr](#connect-over-socket--mcp) | Email alerts you reply to unblock |
 | Connect | ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) [dcolinmorgan/herdr-push](#connect-over-socket--mcp) | Zero-dep event push to herdr-remote |
 | Connect | ![Rust](https://img.shields.io/badge/-555555?logo=rust&logoColor=white&style=flat-square) [herdr-focus-notify](#connect-over-socket--mcp) | Clickable macOS toast jumps to pane |
@@ -344,6 +345,10 @@ A user-level MiMo Code plugin that reports idle / working / blocked / done state
 ![JavaScript](https://img.shields.io/badge/-555555?logo=javascript&logoColor=white&style=flat-square) **[zom-2018/herdr-ntfy-notify](https://github.com/zom-2018/herdr-ntfy-notify)**
 
 A plugin that pushes a structured notification to any ntfy topic when an agent blocks or finishes, so alerts reach your phone, tablet, or desktop regardless of which machine is running the agents. Each message carries the workspace, tab, and pane ID so you know exactly where to return, and a local ntfy server is auto-detected for near-instant delivery before falling back over the network. For developers who want cross-device agent alerts through the open ntfy ecosystem.
+
+![Go](https://img.shields.io/badge/-555555?logo=go&logoColor=white&style=flat-square) **[cobanov/herdr-ntfysh](https://github.com/cobanov/herdr-ntfysh)**
+
+A single Go binary that pushes an ntfy notification the moment a herdr agent finishes a turn or blocks for input, tagging each alert with the workspace and pane so you know where to return. It reads herdr's completion signal from both the explicit `done` status and a `working → idle` transition, and debounces repeats per pane so a flapping agent can't spam you; auth covers Bearer tokens, Basic credentials, and self-hosted TLS with a custom CA. For developers running agents across several workspaces who want their phone to ping only when a session actually needs them, with no runtime dependencies to install.
 
 ![JavaScript](https://img.shields.io/badge/-555555?logo=javascript&logoColor=white&style=flat-square) **[tiny-send/tinysend-herdr](https://github.com/tiny-send/tinysend-herdr)**
 


### PR DESCRIPTION
Adds [cobanov/herdr-ntfysh](https://github.com/cobanov/herdr-ntfysh) to the **Connect over socket & MCP** section — a Go herdr plugin that pushes ntfy notifications when an agent finishes (`done`) or blocks for input.

Added in both places per AGENTS.md: the `At a glance` table row and a blurb under the section.

### PR checklist
- [x] I read AGENTS.md.
- [x] The project is Herdr-specific and publicly accessible.
- [x] Uses the current format (Go badge + blurb) in the Connect section.
- [x] Description is factual and specific — no hype.
- [x] Links work and `npx markdownlint-cli2 "**/*.md"` passes (0 errors).

Notes: distinct from the existing `herdr-ntfy-notify` — single static Go binary with zero runtime deps (no `node`/`curl`), catches completion from both the explicit `done` status and a `working → idle` transition, per-pane debounce, and Bearer/Basic/custom-CA TLS for self-hosted ntfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cobanov/herdr-ntfysh` to the Connect over socket & MCP section and the At a glance table, expanding ntfy alert options for herdr users.
This Go plugin sends ntfy notifications when an agent finishes or blocks, tags workspace/pane, debounces per pane, and needs no runtime deps (supports Bearer/Basic auth and custom-CA TLS).

<sup>Written for commit f14a89967ffa1075abfacea5b9cc62d816ca8357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

