### PR TITLE
Add herdr-ask (command-generation popup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Everything below builds on those primitives — running fleets of agents side by
 | Terminal UX | ![Python](https://img.shields.io/badge/-555555?logo=python&logoColor=white&style=flat-square) [ppggff/herdr-plugin](#worktrees-config--terminal-ux) | Keep macOS input source per pane |
 | Terminal UX | ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) [astkaasa/herdr-tokscale-dashboard](#worktrees-config--terminal-ux) | Tokscale cost dashboard as a pane |
 | Terminal UX | ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) [aiki-sh/aiki-integration-herdr](#worktrees-config--terminal-ux) | Live aiki epic list in a pane |
+| Terminal UX | ![Rust](https://img.shields.io/badge/-555555?logo=rust&logoColor=white&style=flat-square) [TaylorFinklea/herdr-ask](#worktrees-config--terminal-ux) | Generate shell commands; insert without executing |
 | Desktop | ![TypeScript](https://img.shields.io/badge/-555555?logo=typescript&logoColor=white&style=flat-square) [AltanS/collie](#desktop-apps--packaging) | Reply to agents from your phone |
 
 ---
@@ -626,6 +627,10 @@ Wires the Tokscale token/cost dashboard into Herdr as a split pane and a JSON-em
 ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) **[aiki-sh/aiki-integration-herdr](https://github.com/aiki-sh/aiki-integration-herdr)**
 
 Opens a live-refreshing sidebar pane listing your in-flight aiki epics inside Herdr, and its install step bootstraps the companion aiki session-identity hook. For teams already using the aiki task tracker who want epic status visible alongside their agent panes.
+
+![Rust](https://img.shields.io/badge/-555555?logo=rust&logoColor=white&style=flat-square) **[TaylorFinklea/herdr-ask](https://github.com/TaylorFinklea/herdr-ask)**
+
+Binds a popup to any Herdr key where you describe what you want in plain English and get back only the shell command, then review it and insert it into the originating pane with `Ctrl+Enter` — it never runs the command and never appends Enter. Backends are yours to pick: local Ollama or any OpenAI-compatible server with no account, the OpenAI and Anthropic APIs with keys in the OS keychain, or your existing Codex CLI, Claude Code, and Pi logins through ephemeral headless invocations. Conversations stay in memory, and a separate Chat mode answers terminal questions without inserting anything.
 
 ---
 


### PR DESCRIPTION
## What

Adds [**TaylorFinklea/herdr-ask**](https://github.com/TaylorFinklea/herdr-ask) under **Worktrees, config & terminal UX** — a quick-index row and a detailed blurb.

herdr-ask is a Rust popup plugin: bind it to a Herdr key, describe a command in plain English, and it returns only the shell command for you to review and insert into the originating pane with `Ctrl+Enter`. It never executes the command and never appends Enter. Backends include local Ollama / any OpenAI-compatible server, the OpenAI and Anthropic APIs (keys in the OS keychain), and existing Codex CLI / Claude Code / Pi logins via ephemeral headless invocations.

It ships a `herdr-plugin.toml` manifest and installs via `herdr plugin install TaylorFinklea/herdr-ask`; also on crates.io and a Homebrew tap.

## Checklist

- [x] Herdr-specific and publicly accessible
- [x] Current format (badge + blurb), correct section (Worktrees, config & terminal UX)
- [x] Description is factual and specific — no hype
- [x] Links work; `npx markdownlint-cli2 "**/*.md"` passes (0 issues)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `TaylorFinklea/herdr-ask` to the Worktrees, config & terminal UX section with a quick-index row and a short blurb. This Rust popup turns plain English into a shell command, lets you review and insert with `Ctrl+Enter` (never runs), and supports local Ollama, OpenAI-compatible servers, OpenAI and Anthropic APIs, and existing Codex CLI / Claude Code / Pi logins.

<sup>Written for commit 80ff53348a8cb396afc01b20008c7734e721b888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

