### PR TITLE
docs(awesome-list): add richardadonnell/herdr-claude-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Everything below builds on those primitives — running fleets of agents side by
 | Terminal UX | ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) [astkaasa/herdr-tokscale-dashboard](#worktrees-config--terminal-ux) | Tokscale cost dashboard as a pane |
 | Terminal UX | ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) [aiki-sh/aiki-integration-herdr](#worktrees-config--terminal-ux) | Live aiki epic list in a pane |
 | Desktop | ![TypeScript](https://img.shields.io/badge/-555555?logo=typescript&logoColor=white&style=flat-square) [AltanS/collie](#desktop-apps--packaging) | Reply to agents from your phone |
+| Orchestrate | ![PowerShell](https://img.shields.io/badge/-555555?logo=powershell&logoColor=white&style=flat-square) [richardadonnell/herdr-claude-manager](#run--orchestrate-agents) | Windows PowerShell menu for N Claude panes |
 
 ---
 
@@ -294,6 +295,10 @@ Provisions an isolated worktree per branch or GitHub issue — its own ports, `.
 ![Shell](https://img.shields.io/badge/-555555?logo=gnubash&logoColor=white&style=flat-square) **[noor-latif/herd](https://github.com/noor-latif/herd)**
 
 Two companion scripts that spin up a project-scoped Herdr workspace with an N-agent grid (default 2×2, one Pi agent per pane) keyed to the current directory, and relaunch any dead agents when you return. For anyone who wants a repeatable one-command "start a grid of agents for this repo" setup.
+
+![PowerShell](https://img.shields.io/badge/-555555?logo=powershell&logoColor=white&style=flat-square) **[richardadonnell/herdr-claude-manager](https://github.com/richardadonnell/herdr-claude-manager)**
+
+A PowerShell path into Herdr for Windows: name a workspace, say how many Claude Code panes you want, and it tiles any N, labels each pane `<name>-<n>`, launches `claude -n <name>-<n>` in every one, then lists, resumes, or kills those workspaces from the same menu. Each added pane splits the largest existing one, so a count that does not divide into a clean grid still comes out roughly even and there is no layout file to author. `-List` and `-New` skip the menu when a script drives it, and `-SelfTest` asserts the tiler against a live server.
 
 ---
 


### PR DESCRIPTION
Adds [richardadonnell/herdr-claude-manager](https://github.com/richardadonnell/herdr-claude-manager) under **Run & orchestrate agents**, plus its row in the At a glance table.

A PowerShell menu over the default Herdr server: pick a pane count, and it tiles any N, names each pane, and launches `claude -n <name>-<n>` in every one, with list, resume, and kill for the same workspaces. `-List` and `-New` skip the menu for scripts, and `-SelfTest` asserts the tiler against a live server.

I added it because the list currently has no PowerShell entry in this category. Every workspace and session tool here is Shell, Go, Rust, TypeScript, or Python, so Windows users have no in-category option. Closest neighbour is `noor-latif/herd`, which I placed this next to. It differs in targeting Claude Code rather than Pi, tiling arbitrary N rather than a fixed grid, and adding the list/resume/kill side.

## Checklist

- [x] I read [AGENTS.md](./AGENTS.md).
- [x] The project is Herdr-specific and publicly accessible.
- [x] The entry uses the current format (badge + blurb) and is in the right section.
- [x] The description is factual and specific, no hype, no filler.
- [x] Links work and `npx markdownlint-cli2 "**/*.md"` passes (0 issues in 9 files).

MIT licensed, lint CI green, tested against Herdr 0.7.5-preview (protocol 17).

https://claude.ai/code/session_01SRt18mYWJMvXTBZvrkypcP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `richardadonnell/herdr-claude-manager` to the Awesome Herdr README under Run & orchestrate agents and to the At a glance table. It’s a Windows PowerShell manager that tiles any number of Claude Code panes, names them, and lets you list, resume, and kill workspaces.

<sup>Written for commit 8ac2c426408e9b315db516fb12c6b13d6a65bcc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

