### PR TITLE
docs(awesome-list): add neyham/herdr-paddock to remote viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Output inspection, logs, and transcripts (9)](#output-inspection-logs-and-transcripts)
    - [Dotfiles and ready-made configuration (6)](#dotfiles-and-ready-made-configuration)
    - [Plugin collections and developer frameworks (3)](#plugin-collections-and-developer-frameworks)
-6. [Apps, companion integrations, and installation (75)](#6-apps-companion-integrations-and-installation)
+6. [Apps, companion integrations, and installation (76)](#6-apps-companion-integrations-and-installation)
    - [Native desktop and mobile apps (11)](#native-desktop-and-mobile-apps)
-   - [Web dashboards and remote viewers (16)](#web-dashboards-and-remote-viewers)
+   - [Web dashboards and remote viewers (17)](#web-dashboards-and-remote-viewers)
    - [Hardware and ambient displays (12)](#hardware-and-ambient-displays)
    - [Plugins and supporting utilities (27)](#plugins-and-supporting-utilities)
    - [Setup, packages, and version management (9)](#setup-packages-and-version-management)
@@ -1116,7 +1116,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Web dashboards and remote viewers
 
-*16 projects. Browser-based monitors, remote controls, and visual scenes for following Herdr agents from another screen or device.**
+*17 projects. Browser-based monitors, remote controls, and visual scenes for following Herdr agents from another screen or device.**
 
 | Project | What it does |
 |---|---|
@@ -1136,6 +1136,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**tigorlazuardi/herdr-web-tui**](https://github.com/tigorlazuardi/herdr-web-tui) | A lightweight browser and progressive web app client for daemon-mode Herdr, with terminal viewing, pane navigation, and plugin launching on desktop or mobile devices. |
 | [**funsaized/herdr-mise**](https://github.com/funsaized/herdr-mise) | Represents Herdr agents as line cooks and animates their work, tool use, and blocked states from live socket events. |
 | [**gabrielbarretoo/herdr-medieval**](https://github.com/gabrielbarretoo/herdr-medieval) | A Three.js visualization that turns Herdr workspaces into medieval camps and panes into animated adventurers whose behavior reflects each agent's state. |
+| [**neyham/herdr-paddock**](https://github.com/neyham/herdr-paddock) | Shows every Herdr agent as a card in a scrollable waterfall feed over plain SSH, with blocked agents pinned to the top and cleaned pane output on each card. Runs standalone or as a Herdr plugin popup, responsive down to a 40-column phone terminal, with no relay or web server. |
 
 ### Hardware and ambient displays
 

--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ## 6. Apps, companion integrations, and installation
 
-*75 projects. Desktop and mobile clients, browser dashboards, physical status devices, supporting plugins, and reproducible installation tools.*
+*76 projects. Desktop and mobile clients, browser dashboards, physical status devices, supporting plugins, and reproducible installation tools.*
 
 ### Native desktop and mobile apps
 


### PR DESCRIPTION
## What changed?

- Adds [neyham/herdr-paddock](https://github.com/neyham/herdr-paddock) to **Web dashboards and remote viewers** (appended last per star ranking; new project). Paddock renders the herd as a card-wall waterfall feed in a TUI over plain SSH — blocked agents pinned on top, cleaned pane output on each card — standalone or as a Herdr plugin popup, usable from a 40-column phone terminal. Happy to move it to another section if you think it fits better.
- Updates the section and TOC counts (16 → 17, 75 → 76).

Disclosure: I am the author of paddock.

## Checklist

- [x] The project is Herdr-specific.
- [x] The entry uses the list format.
- [x] The description is factual and specific.
- [x] Links work.
- [x] Any new docs cite upstream sources.

`npx markdownlint-cli2 "**/*.md"` passes with 0 issues.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `neyham/herdr-paddock` to Web dashboards and remote viewers and updates counts in the TOC and section headers. This keeps the awesome list current and consistent.

**Review notes**
- Confirm the entry is appended at the end to match star-based ordering.
- Confirm counts update: 76 under Apps, companion integrations, and installation; 17 under Web dashboards and remote viewers.

<sup>Written for commit ba073cd18cf281f23c6dd1c4d8c4c956a5f79fbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

