### PR TITLE
Add herdr-fleece to context meters and rate-limit gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Command palettes and workspace switchers (14)](#command-palettes-and-workspace-switchers)
    - [Status lines, sidebars, and tab synchronization (70)](#status-lines-sidebars-and-tab-synchronization)
    - [Status overlays, HUDs, and agent timers (15)](#status-overlays-huds-and-agent-timers)
-   - [Context meters and rate-limit gauges (7)](#context-meters-and-rate-limit-gauges)
+   - [Context meters and rate-limit gauges (8)](#context-meters-and-rate-limit-gauges)
    - [Output inspection, logs, and transcripts (9)](#output-inspection-logs-and-transcripts)
    - [Dotfiles and ready-made configuration (6)](#dotfiles-and-ready-made-configuration)
    - [Plugin collections and developer frameworks (3)](#plugin-collections-and-developer-frameworks)
@@ -1039,7 +1039,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Context meters and rate-limit gauges
 
-*7 projects. Live token headroom meters, quota tracking, and agent cost gauges.*
+*8 projects. Live token headroom meters, quota tracking, and agent cost gauges.*
 
 | Project | What it does |
 |---|---|
@@ -1050,6 +1050,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**szrenwei/herdr-agent-metrics**](https://github.com/szrenwei/herdr-agent-metrics) | Tracks context-window and token metrics for Claude Code, Codex, and TraeX sessions and summarizes them in a small Herdr overlay. |
 | [**tomys22/herdr-agent-usage-plugin**](https://github.com/tomys22/herdr-agent-usage-plugin) | Displays Claude, Codex, and Gemini API usage, including session and weekly percentages and reset times, in a Herdr split. |
 | [**ram4-dev/herdr-codex-usage**](https://github.com/ram4-dev/herdr-codex-usage) | Detects installed agents and shows their usage quotas inside Herdr. |
+| [**sjh9714/herdr-fleece**](https://github.com/sjh9714/herdr-fleece) | Shows live tokens, dollars, and a $/hour burn rate for every Herdr pane in one `npx` console, attributing spend to panes by working directory. Reads the usage files Claude Code and Codex already write, keeps unattributed spend visible as an off-herd line, and prints the whole board as JSON for status bars. |
 
 ### Output inspection, logs, and transcripts
 


### PR DESCRIPTION
Adds one entry and bumps both counts (section header and ToC), 7 to 8.

**What it is.** A live cost console for the whole herd: one row per pane with agent kind, Herdr's working/blocked/idle status, tokens, dollars, and a $/hour burn rate over a trailing five-minute window. Runs as `npx herdr-fleece`, no install or config.

**Why it is not a duplicate of the section's existing entries.** The seven current projects are quota-window and context meters (percent of rate limit, window resets). None shows dollars per pane, none shows a burn rate, and none attributes spend across mixed agents in one board. herdr-fleece reads the usage files Claude Code and Codex already write (parser follows ccusage's conventions, message-id dedupe included, cross-checked against ccusage on live data within 2%), asks the socket one `pane.list` per tick, and joins the two by working directory. Spend no pane owns stays visible as an off-herd line rather than disappearing.

Checklist run before opening. Entry is verb-first and two sentences, the project is Herdr-specific and public, `npx markdownlint-cli2` passes with 0 issues.

The README hero is a real screenshot of the console against a live herd, not a mock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `sjh9714/herdr-fleece` to the "Context meters and rate-limit gauges" list and updates counts from 7 to 8 in the ToC and section header. This matters because `herdr-fleece` provides per-pane tokens, dollars, and $/hour burn rate with spend attribution by working directory, which the existing entries do not cover.

**Review notes**
- Verify the repository link and one-line summary accurately describe `herdr-fleece`.
- Confirm both count updates (ToC and section header) are consistent.

<sup>Written for commit 512b1dcc6c1311eed6f5a3e51de60200312bb765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

