### PR TITLE
docs(awesome-list): add lntvan166/paddock to web dashboards and remote viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Output inspection, logs, and transcripts (9)](#output-inspection-logs-and-transcripts)
    - [Dotfiles and ready-made configuration (6)](#dotfiles-and-ready-made-configuration)
    - [Plugin collections and developer frameworks (3)](#plugin-collections-and-developer-frameworks)
-6. [Apps, companion integrations, and installation (76)](#6-apps-companion-integrations-and-installation)
+6. [Apps, companion integrations, and installation (77)](#6-apps-companion-integrations-and-installation)
    - [Native desktop and mobile apps (11)](#native-desktop-and-mobile-apps)
-   - [Web dashboards and remote viewers (17)](#web-dashboards-and-remote-viewers)
+   - [Web dashboards and remote viewers (18)](#web-dashboards-and-remote-viewers)
    - [Hardware and ambient displays (12)](#hardware-and-ambient-displays)
    - [Plugins and supporting utilities (27)](#plugins-and-supporting-utilities)
    - [Setup, packages, and version management (9)](#setup-packages-and-version-management)
@@ -1097,7 +1097,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ## 6. Apps, companion integrations, and installation
 
-*76 projects. Desktop and mobile clients, browser dashboards, physical status devices, supporting plugins, and reproducible installation tools.*
+*77 projects. Desktop and mobile clients, browser dashboards, physical status devices, supporting plugins, and reproducible installation tools.*
 
 ### Native desktop and mobile apps
 
@@ -1119,7 +1119,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Web dashboards and remote viewers
 
-*17 projects. Browser-based monitors, remote controls, and visual scenes for following Herdr agents from another screen or device.**
+*18 projects. Browser-based monitors, remote controls, and visual scenes for following Herdr agents from another screen or device.**
 
 | Project | What it does |
 |---|---|
@@ -1140,6 +1140,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**funsaized/herdr-mise**](https://github.com/funsaized/herdr-mise) | Represents Herdr agents as line cooks and animates their work, tool use, and blocked states from live socket events. |
 | [**gabrielbarretoo/herdr-medieval**](https://github.com/gabrielbarretoo/herdr-medieval) | A Three.js visualization that turns Herdr workspaces into medieval camps and panes into animated adventurers whose behavior reflects each agent's state. |
 | [**neyham/herdr-paddock**](https://github.com/neyham/herdr-paddock) | Shows every Herdr agent as a card in a scrollable waterfall feed over plain SSH, with blocked agents pinned to the top and cleaned pane output on each card. Runs standalone or as a Herdr plugin popup, responsive down to a 40-column phone terminal, with no relay or web server. |
+| [**lntvan166/paddock**](https://github.com/lntvan166/paddock) | Groups Herdr agents into needs-you, working, and idle in a phone-sized web dashboard, and answers a blocked agent using the prompt's own option labels instead of a guessed keystroke. Ships as a single binary that speaks Herdr's socket protocol directly, installs to the iOS Home Screen as an app, and sends a Telegram alert once an agent's state has held. |
 
 ### Hardware and ambient displays
 


### PR DESCRIPTION
## What changed?

- Adds [lntvan166/paddock](https://github.com/lntvan166/paddock) to **Web dashboards and remote viewers**, appended last in the subcategory per the star ranking. It is a mobile-first web dashboard that groups agents into *needs you* / *working* / *idle*, renders full-colour pane output that reflows to a phone screen, and answers a blocked agent with the prompt's own option labels rather than a guessed keystroke. Single Bun-compiled binary, speaks herdr's socket protocol directly (no relay service), installs to the iOS Home Screen as a PWA, optional Telegram alerts once a state has held. Happy to move it if you think another section fits better.
- Updates the counts: Web dashboards and remote viewers 16 → 17, section 6 header and TOC 75 → 76.

**Heads-up on a name collision:** open PR #8 adds `neyham/herdr-paddock`, which is an unrelated project that happens to share the name — that one is a TUI card-wall over SSH, this one is a browser dashboard. Both entries can coexist; the `owner/repo` prefixes keep them distinguishable, but flagging it so it does not look like a duplicate. That PR touches the same table rows, so if it merges first I will rebase.

For context, the list already includes [dcolinmorgan/herdr-remote](https://github.com/dcolinmorgan/herdr-remote), which is credited in paddock's README as the origin of the idea. paddock reuses the concept and none of the implementation — herdr-remote relays through a Python service, paddock talks to the socket directly — and the credit is prominent in the README.

Disclosure: I am the author of paddock.

## Checklist

- [x] I read [AGENTS.md](./AGENTS.md).
- [x] The project is Herdr-specific and publicly accessible (MIT, tagged releases, prebuilt binaries).
- [x] The entry uses the current format (2-column table row) and is in the right section.
- [x] The description is factual and specific — no hype, no filler.
- [x] Links work and `npx markdownlint-cli2 "**/*.md"` passes with **0 issues**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `lntvan166/paddock` to the “Web dashboards and remote viewers” section and updates the TOC and section counts to stay accurate.

- Appends the entry at the end of the subcategory per star ranking and uses the standard two-column format.
- Updates counts: Apps section 76 → 77; Web dashboards and remote viewers 17 → 18.
- The entry now sits alongside `neyham/herdr-paddock`; the owner/repo prefixes keep the two same-named projects distinguishable.

<sup>Written for commit 467acfe3b56f5819206302f44e0ea5094d0fb503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

