### PR TITLE
docs(awesome-list): add vjeantet/herdr-mission-control

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Fuzzy session switchers and terminal pickers (46)](#fuzzy-session-switchers-and-terminal-pickers)
    - [Persistence, snapshots, and state restoration (11)](#persistence-snapshots-and-state-restoration)
    - [Workspace and multi-session management (8)](#workspace-and-multi-session-management)
-5. [Worktrees and terminal experience (360)](#5-worktrees-and-terminal-experience)
+5. [Worktrees and terminal experience (361)](#5-worktrees-and-terminal-experience)
    - [Git worktree automation (99)](#git-worktree-automation)
    - [Workspace lifecycle and multi-repository tools (4)](#workspace-lifecycle-and-multi-repository-tools)
    - [Diff review and code inspection (21)](#diff-review-and-code-inspection)
    - [File viewers and markdown previews (19)](#file-viewers-and-markdown-previews)
-   - [Pane navigation and overlay hints (11)](#pane-navigation-and-overlay-hints)
+   - [Pane navigation and overlay hints (12)](#pane-navigation-and-overlay-hints)
    - [Terminal keybindings and shortcut helpers (81)](#terminal-keybindings-and-shortcut-helpers)
    - [Command palettes and workspace switchers (14)](#command-palettes-and-workspace-switchers)
    - [Status lines, sidebars, and tab synchronization (71)](#status-lines-sidebars-and-tab-synchronization)
@@ -641,7 +641,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ## 5. Worktrees and terminal experience
 
-*360 projects. Git worktree automation, diff review, navigation, status displays, logs, and ready-made terminal configurations.*
+*361 projects. Git worktree automation, diff review, navigation, status displays, logs, and ready-made terminal configurations.*
 
 ### Git worktree automation
 
@@ -816,7 +816,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Pane navigation and overlay hints
 
-*11 projects. Direct 1-character overlay hints and smart directional pane jumping.*
+*12 projects. Direct 1-character overlay hints and smart directional pane jumping.*
 
 | Project | What it does |
 |---|---|
@@ -831,6 +831,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**yigitkg/herdr-open-local-paths**](https://github.com/yigitkg/herdr-open-local-paths) | Finds file and folder paths mentioned in recent pane output and opens them with the operating system or reveals them in a file manager. When several paths exist, a picker lists files before folders. |
 | [**RooseveltAdvisors/herdr-leap**](https://github.com/RooseveltAdvisors/herdr-leap) | Provides EasyMotion or Leap-style character jumps and selection-to-copy inside Herdr terminal panes. |
 | [**stappmus/Udder**](https://github.com/stappmus/Udder) | Shows Herdr agents in the Omarchy bar, notifies when work finishes, and jumps back to the relevant pane. |
+| [**vjeantet/herdr-mission-control**](https://github.com/vjeantet/herdr-mission-control) | Opens a full-screen overlay showing every pane of the current workspace as a live tile grouped by tab, with styled ANSI previews and agent status. Arrows or `hjkl` move the selection, `Enter` focuses the pane, and `Backspace` closes it without leaving the overview. |
 
 ### Terminal keybindings and shortcut helpers
 


### PR DESCRIPTION
## What changed?

- Adds `vjeantet/herdr-mission-control` to §5 › Pane navigation and overlay hints, and bumps the section and table-of-contents counts (11 → 12, 359 → 360).

## Checklist

- [x] The project is Herdr-specific.
- [x] The entry uses the list format.
- [x] The description is factual and specific.
- [x] Links work.
- [x] Any new docs cite upstream sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vjeantet/herdr-mission-control` to the Pane navigation and overlay hints section of the awesome list, and updates the section and table-of-contents counts (11 → 12, 360 → 361).

<sup>Written for commit 1f9dd9bbc82715516299e37636955bdbf24c55e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

