### PR TITLE
docs(awesome-list): add vjeantet/herdr-scratchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Fuzzy session switchers and terminal pickers (46)](#fuzzy-session-switchers-and-terminal-pickers)
    - [Persistence, snapshots, and state restoration (11)](#persistence-snapshots-and-state-restoration)
    - [Workspace and multi-session management (8)](#workspace-and-multi-session-management)
-5. [Worktrees and terminal experience (361)](#5-worktrees-and-terminal-experience)
+5. [Worktrees and terminal experience (362)](#5-worktrees-and-terminal-experience)
    - [Git worktree automation (99)](#git-worktree-automation)
    - [Workspace lifecycle and multi-repository tools (4)](#workspace-lifecycle-and-multi-repository-tools)
    - [Diff review and code inspection (21)](#diff-review-and-code-inspection)
    - [File viewers and markdown previews (19)](#file-viewers-and-markdown-previews)
    - [Pane navigation and overlay hints (12)](#pane-navigation-and-overlay-hints)
-   - [Terminal keybindings and shortcut helpers (81)](#terminal-keybindings-and-shortcut-helpers)
+   - [Terminal keybindings and shortcut helpers (82)](#terminal-keybindings-and-shortcut-helpers)
    - [Command palettes and workspace switchers (14)](#command-palettes-and-workspace-switchers)
    - [Status lines, sidebars, and tab synchronization (71)](#status-lines-sidebars-and-tab-synchronization)
    - [Status overlays, HUDs, and agent timers (15)](#status-overlays-huds-and-agent-timers)
@@ -641,7 +641,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ## 5. Worktrees and terminal experience
 
-*361 projects. Git worktree automation, diff review, navigation, status displays, logs, and ready-made terminal configurations.*
+*362 projects. Git worktree automation, diff review, navigation, status displays, logs, and ready-made terminal configurations.*
 
 ### Git worktree automation
 
@@ -835,7 +835,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Terminal keybindings and shortcut helpers
 
-*81 projects. Custom keymap packs, leader-key setups, and prefix-free navigation.*
+*82 projects. Custom keymap packs, leader-key setups, and prefix-free navigation.*
 
 | Project | What it does |
 |---|---|
@@ -920,6 +920,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**donghaolicd/herdr-teams-notify**](https://github.com/donghaolicd/herdr-teams-notify) | Sends bounded Microsoft Teams notifications for Herdr agent lifecycle events. |
 | [**capt-marbles/herdr-jcode-integration**](https://github.com/capt-marbles/herdr-jcode-integration) | Reports Jcode session and lifecycle state to Herdr. |
 | [**DMelisena/shipmates**](https://github.com/DMelisena/shipmates) | A Hermes plugin offering a preconfigured Kun Chen-style Herdr and OpenCode first-mate workflow. The source catalog does not describe its individual controls. |
+| [**vjeantet/herdr-scratchpad**](https://github.com/vjeantet/herdr-scratchpad) | Docks a plain-text scratchpad at the bottom of a tab, one persistent buffer per tab, for composing a prompt where Enter can't send it half-finished. `Ctrl+E` moves it, or just the selection, into an agent of the same tab without submitting; `Ctrl+C` copies over OSC 52. |
 
 ### Command palettes and workspace switchers
 


### PR DESCRIPTION
Adds [vjeantet/herdr-scratchpad](https://github.com/vjeantet/herdr-scratchpad) to **5. Worktrees and terminal experience → Terminal keybindings and shortcut helpers**.

A Rust plugin that docks a plain-text scratchpad at the bottom of a tab: one persistent buffer per tab, for writing a prompt somewhere Enter cannot send it half-finished. `Ctrl+E` moves the buffer, or just the selection, into an agent of the same tab without submitting — the scratchpad clears and focus follows, so you land in front of your text and send when you mean to. `Ctrl+C` copies over OSC 52, so the text reaches the clipboard of the terminal you connect *from*. The toggle is a plugin action you bind to a key of your own; the plugin ships no keybinding.

MIT, macOS and Linux, prebuilt binaries published per release (5 targets, the Linux ones static musl).

Counts updated: subsection 81 → 82, section 5 total 359 → 360.

Note: I also have #14 open, which bumps the same section 5 total line (359 → 360). Whichever of the two merges second will need that line rebased to 361 — happy to do it as soon as the first one lands.

## Pull request checklist

- [x] I read [AGENTS.md](./AGENTS.md).
- [x] The project is Herdr-specific and publicly accessible.
- [x] The entry uses the current format (badge + blurb) and is in the right section.
- [x] The description is factual and specific — no hype, no filler.
- [x] Links work and `npx markdownlint-cli2 "**/*.md"` passes (0 issues in 0 files).
