### PR TITLE
Add parker-brown-family/omarchy-crook to status overlays, HUDs, and agent timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Fuzzy session switchers and terminal pickers (46)](#fuzzy-session-switchers-and-terminal-pickers)
    - [Persistence, snapshots, and state restoration (11)](#persistence-snapshots-and-state-restoration)
    - [Workspace and multi-session management (8)](#workspace-and-multi-session-management)
-5. [Worktrees and terminal experience (363)](#5-worktrees-and-terminal-experience)
+5. [Worktrees and terminal experience (364)](#5-worktrees-and-terminal-experience)
    - [Git worktree automation (99)](#git-worktree-automation)
    - [Workspace lifecycle and multi-repository tools (4)](#workspace-lifecycle-and-multi-repository-tools)
    - [Diff review and code inspection (21)](#diff-review-and-code-inspection)
@@ -45,7 +45,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Terminal keybindings and shortcut helpers (82)](#terminal-keybindings-and-shortcut-helpers)
    - [Command palettes and workspace switchers (15)](#command-palettes-and-workspace-switchers)
    - [Status lines, sidebars, and tab synchronization (71)](#status-lines-sidebars-and-tab-synchronization)
-   - [Status overlays, HUDs, and agent timers (15)](#status-overlays-huds-and-agent-timers)
+   - [Status overlays, HUDs, and agent timers (16)](#status-overlays-huds-and-agent-timers)
    - [Context meters and rate-limit gauges (7)](#context-meters-and-rate-limit-gauges)
    - [Output inspection, logs, and transcripts (9)](#output-inspection-logs-and-transcripts)
    - [Dotfiles and ready-made configuration (6)](#dotfiles-and-ready-made-configuration)
@@ -641,7 +641,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ## 5. Worktrees and terminal experience
 
-*363 projects. Git worktree automation, diff review, navigation, status displays, logs, and ready-made terminal configurations.*
+*364 projects. Git worktree automation, diff review, navigation, status displays, logs, and ready-made terminal configurations.*
 
 ### Git worktree automation
 
@@ -1024,7 +1024,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Status overlays, HUDs, and agent timers
 
-*15 projects. Floating status HUDs, turn timers, and keep-awake utilities.*
+*16 projects. Floating status HUDs, turn timers, and keep-awake utilities.*
 
 | Project | What it does |
 |---|---|
@@ -1043,6 +1043,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**shadowfax92/herdr-scratch**](https://github.com/shadowfax92/herdr-scratch) | Gives each Herdr pane a persistent scratch overlay backed by a private tmux session, keeping notes, REPLs, and side commands tied to that pane. |
 | [**zetlen/herdr-hud**](https://github.com/zetlen/herdr-hud) | A floating, customizable HUD for host, network, session, and agent metrics, with support for extra data supplied by shell scripts. |
 | [**speardragon/herdr-status-platform**](https://github.com/speardragon/herdr-status-platform) | A Herdr status-platform integration. The source catalog does not explain its displayed data or controls. |
+| [**parker-brown-family/omarchy-crook**](https://github.com/parker-brown-family/omarchy-crook) | Puts Herdr agent state on the Omarchy desktop bar: one icon that turns urgent when an agent is blocked, and a tray listing every agent grouped by whether it needs you. Clicking a row focuses that pane and raises the terminal window on Hyprland. |
 
 ### Context meters and rate-limit gauges
 


### PR DESCRIPTION
Adds one entry to **Status overlays, HUDs, and agent timers**, and bumps the three counts that section touches (subcategory 15 → 16, domain 5 total 359 → 360).

| Project | What it does |
|---|---|
| [**parker-brown-family/omarchy-crook**](https://github.com/parker-brown-family/omarchy-crook) | Puts Herdr agent state on the Omarchy desktop bar: one icon that turns urgent when an agent is blocked, and a tray listing every agent grouped by whether it needs you. Clicking a row focuses that pane and raises the terminal window on Hyprland. |

Why this section rather than *Status lines, sidebars, and tab synchronization*: it is not a Herdr status line — it is a desktop-bar widget outside the terminal, in the same family as the HUDs and always-on-top overlays already listed here. The fifteen current entries are macOS or platform-neutral; this is the first aimed at a Linux desktop bar.

It is a Herdr plugin proper (`[[events]]` on `pane.agent_status_changed`, `pane.agent_detected`, `pane.exited`, `pane.closed`, plus a `[[startup]]` hook), MIT, v0.2.0, already listed on the herdr plugin marketplace. Requires Herdr 0.7.5+ — `[[startup]]` hooks arrived there. 72 stub-driven tests, CI runs shellcheck and a mutation check.

## Pull request checklist

- [x] I read [AGENTS.md](./AGENTS.md).
- [x] The project is Herdr-specific and publicly accessible.
- [x] The entry uses the current format (badge + blurb) and is in the right section.
- [x] The description is factual and specific — no hype, no filler.
- [x] Links work and `npx markdownlint-cli2 "**/*.md"` passes (0 issues in 0 files).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `parker-brown-family/omarchy-crook` to the Status overlays, HUDs, and agent timers section and bumps the counts that section touches (subcategory 15 → 16, domain total 363 → 364).

- First entry in that section aimed at a Linux desktop bar; the existing fifteen are macOS or platform-neutral.
- It renders Herdr agent state as an Omarchy desktop-bar icon and a tray grouped by whether each agent needs attention; clicking focuses the pane and raises the terminal on Hyprland.
- Requires Herdr 0.7.5+ because it relies on `[[startup]]` hooks.

<sup>Written for commit f0b80899787f4f38c7e266668ecd3c2d08470dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

