### PR TITLE
docs(awesome-list): add oddurs/herdr-namesync

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
    - [Vim, Kakoune, and other editors (11)](#vim-kakoune-and-other-editors)
    - [REPL and code dispatchers (1)](#repl-and-code-dispatchers)
    - [Editor plugins and bridges (2)](#editor-plugins-and-bridges)
-4. [Switch and restore sessions (64)](#4-switch-and-restore-sessions)
+4. [Switch and restore sessions (65)](#4-switch-and-restore-sessions)
    - [Fuzzy session switchers and terminal pickers (46)](#fuzzy-session-switchers-and-terminal-pickers)
    - [Persistence, snapshots, and state restoration (11)](#persistence-snapshots-and-state-restoration)
-   - [Workspace and multi-session management (7)](#workspace-and-multi-session-management)
+   - [Workspace and multi-session management (8)](#workspace-and-multi-session-management)
 5. [Worktrees and terminal experience (359)](#5-worktrees-and-terminal-experience)
    - [Git worktree automation (99)](#git-worktree-automation)
    - [Workspace lifecycle and multi-repository tools (4)](#workspace-lifecycle-and-multi-repository-tools)
@@ -549,7 +549,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ## 4. Switch and restore sessions
 
-*64 projects. Pickers, switchers, snapshots, restoration tools, and managers for moving among persistent Herdr sessions.*
+*65 projects. Pickers, switchers, snapshots, restoration tools, and managers for moving among persistent Herdr sessions.*
 
 ### Fuzzy session switchers and terminal pickers
 
@@ -624,7 +624,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 
 ### Workspace and multi-session management
 
-*7 projects. Managers for creating, grouping, naming, attaching to, and cleaning up several sessions.**
+*8 projects. Managers for creating, grouping, naming, attaching to, and cleaning up several sessions.**
 
 | Project | What it does |
 |---|---|
@@ -635,6 +635,7 @@ Official links: [Website](https://herdr.dev/) · [GitHub](https://github.com/ogu
 | [**to4iki/herdr-unread-jump**](https://github.com/to4iki/herdr-unread-jump) | Jumps to the next Herdr pane needing attention, prioritizing blocked agents before cycling through completed tasks. |
 | [**dantehemerson/herdr-last-tab**](https://github.com/dantehemerson/herdr-last-tab) | Tracks tab focus history and returns to the previously active Herdr tab with one keystroke. |
 | [**osamahbeig/herdr-grove**](https://github.com/osamahbeig/herdr-grove) | Displays projects and directories as a grouped tree in a Herdr popup and opens the selected workspace or folder by key or click. |
+| [**oddurs/herdr-namesync**](https://github.com/oddurs/herdr-namesync) | Keeps workspace, tab, and agent names current as the work changes, reading the intent the coding agent already publishes as its terminal title. Applies a rename policy with debouncing, rate limits, and locks for names you set by hand, and runs without a model unless you configure an OpenAI-compatible endpoint for stale titles. |
 
 ---
 


### PR DESCRIPTION
Adds [oddurs/herdr-namesync](https://github.com/oddurs/herdr-namesync) to **Workspace and multi-session management**, appended at the end of the table since the section is ranked by stars and this project has none yet.

It sits alongside the existing renamers but does a different thing. The ones listed name a session once, from its first prompt or the current title. This one is built around deciding *when* a name should change: it debounces, rate limits, compares against the previous name before replacing it, and locks any name a person set by hand. It also detects when an agent's title has gone stale, which is the failure mode of naming from the first prompt on a session that runs all day.

It reads the agent's own terminal title by default, so it needs no model, no API key and no toolchain beyond Node. A model is optional and only consulted once the free answer has demonstrably failed.

Checklist:

- [x] I read AGENTS.md.
- [x] The project is Herdr-specific and publicly accessible.
- [x] The entry uses the current format (badge + blurb) and is in the right section.
- [x] The description is factual and specific — no hype, no filler.
- [x] Links work and `npx markdownlint-cli2 "**/*.md"` passes (0 issues).

Thanks for maintaining this list — it is genuinely how I found most of the ecosystem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `oddurs/herdr-namesync` to the Workspace and multi-session management section of the awesome list and updates the project count from 7 to 8.

- Differs from existing renamers by deciding when to rename: it debounces, rate limits, compares against previous names, and locks manually set names.
- Detects stale agent titles and runs without a model unless an OpenAI-compatible endpoint is configured.

<sup>Written for commit 62969a86d4db753f56899f51ee461cf85e7e5727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-herdr/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

